### PR TITLE
Make openldap start without manual creation of config dir

### DIFF
--- a/openLDAPServer/README.md
+++ b/openLDAPServer/README.md
@@ -9,7 +9,7 @@ docker-ce (Docker Community Edition) environment set. For information on Docker 
 operating environment, see [Docker Communit Edition](https://store.docker.com/search?q=Docker%20Community%20Edition&type=edition&offering=community).
 Make sure that docker-ce deamon has minumum of 2 GiB of free memory for open LDAP container.
 
-To build and run open LDAP docker container, use openldapDocker.sh script.
+To build and run open LDAP docker container, use openldap.sh script.
 This script will create the following docker image:
 ```
 Name: openldap
@@ -24,12 +24,13 @@ The openldap server is preconfigured to create a set of groups and users that
 can be used in configured policies in IBM IoT MessageSight server:
 
 ```
-Group: MsgGroup1   Users: MsgUser1, MsgUser2, MsgUser3
-Group: MsgGroup2   Users: MsgUser1, MsgUser4, MsgUser5
+Group: MsgGroup1               Users: msgUser1, msgUser2
+Group: MsgGroup2               Users: msgUser1, msgUser3, msgUser4, msgUser5
+Group: AllAuthenticatedUsers   Users: msgUser1, msgUser2, msgUser3, msgUser4, msgUser5
 ```
 
 The openldap server bind password is set to msDemoPassw0rd.
-To change the password, edit the value of BINDPASSWD variable in *openldapDocker.sh*
+To change the password, edit the value of BINDPASSWD variable in *openldap.sh*
 script.
 
 By default the user MsgUser1 ... MsgUser5 password is set to testPassw0rd.
@@ -86,7 +87,7 @@ You can use the following object configuration data in the payload of POST metho
     "BindDN": "cn=Manager,o=IBM",
     "BindPassword": "msDemoPassw0rd",
     "UserSuffix": "ou=users,ou=MessageSight,o=IBM",
-    "GroupSuffix": "ou=groups,ou=MessageSight,o=ibm",
+    "GroupSuffix": "ou=groups,ou=MessageSight,o=IBM",
     "UserIdMap": "*:cn",
     "GroupIdMap": "*:cn",
     "GroupMemberIdMap": "member"
@@ -109,30 +110,25 @@ You can also use IBM MessageSight WebUI to configure external LDAP object.
 You can use the following users and groups for MessageSight messaging test:
 
 ```
-User Name: MsgUser1
+User Name: msgUser1
 Password:  testPassw0rd
-Member of Group: MsgGroup1
-Member of Group: MsgGroup2
+Member of Group: msgGroup1, msgGroup2 & AllAuthenticatedUsers
 
-
-User Name: MsgUser2
+User Name: msgUser2
 Password:  testPassw0rd
-Member of Group: MsgGroup1
+Member of Group: msgGroup1 & AllAuthenticatedUsers
 
-
-User Name: MsgUser3
+User Name: msgUser3
 Password:  testPassw0rd
-Member of Group: MsgGroup1
+Member of Group: msgGroup2 & AllAuthenticatedUsers
 
-
-User Name: MsgUser4
+User Name: msgUser4
 Password:  testPassw0rd
-Member of Group: MsgGroup2
+Member of Group: msgGroup2 & AllAuthenticatedUsers
 
-
-User Name: MsgUser5
+User Name: msgUser5
 Password:  testPassw0rd
-Member of Group: MsgGroup2
+Member of Group: msgGroup2 & AllAuthenticatedUsers
 
 ```
 

--- a/openLDAPServer/openldap.sh
+++ b/openLDAPServer/openldap.sh
@@ -156,11 +156,11 @@ function build_image() {
         rm -f slapd.conf.bak
     fi
 
-    if [ "${USERPASSWD}" != "msDemoPassw0rd" ]
+    if [ "${USERPASSWD}" != "testPassw0rd" ]
     then
         cd ${CURDIR}/opt/openldap
         cp users.ldif.org users.ldif
-        sed -i'.bak' -e 's/msDemoPassw0rd/'${USERPASSWD}'/g' users.ldif
+        sed -i'.bak' -e 's/testPassw0rd/'${USERPASSWD}'/g' users.ldif
         rm -f users.ldif.bak
     fi
 

--- a/openLDAPServer/opt/openldap/slapd.conf
+++ b/openLDAPServer/opt/openldap/slapd.conf
@@ -26,8 +26,8 @@ include /etc/openldap/schema/ppolicy.schema
 
 loglevel 64
 logfile /ima/logs/openldap.log
-pidfile /opt/openldap/config/slapd.pid
-argsfile /opt/openldap/config/slapd.args
+pidfile /opt/openldap/openldap-data/slapd.pid
+argsfile /opt/openldap/openldap-data/slapd.args
 
 # specifies the maximum number of entries to return from a search operation
 sizelimit 500

--- a/openLDAPServer/opt/openldap/slapd.conf.org
+++ b/openLDAPServer/opt/openldap/slapd.conf.org
@@ -27,8 +27,8 @@ include /etc/openldap/schema/ppolicy.schema
 
 loglevel 64
 logfile /ima/logs/openldap.log
-pidfile /opt/openldap/config/slapd.pid
-argsfile /opt/openldap/config/slapd.args
+pidfile /opt/openldap/openldap-data/slapd.pid
+argsfile /opt/openldap/openldap-data/slapd.args
 
 # specifies the maximum number of entries to return from a search operation
 sizelimit 500

--- a/openLDAPServer/opt/openldap/users.ldif
+++ b/openLDAPServer/opt/openldap/users.ldif
@@ -100,14 +100,23 @@ objectClass: top
 cn: MsgGroup1
 member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser2,ou=users,ou=MessageSight,o=IBM
-member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
 
 dn: cn=MsgGroup2,ou=groups,ou=MessageSight,o=IBM
 objectClass: groupOfNames
 objectClass: top
 cn: MsgGroup2
 member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser4,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser5,ou=users,ou=MessageSight,o=IBM
 
+dn: cn=AllAuthenticatedUsers,ou=groups,ou=MessageSight,o=IBM
+objectClass: groupOfNames
+objectClass: top
+cn: AllAuthenticatedUsers
+member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser2,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser4,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser5,ou=users,ou=MessageSight,o=IBM
 

--- a/openLDAPServer/opt/openldap/users.ldif.org
+++ b/openLDAPServer/opt/openldap/users.ldif.org
@@ -52,7 +52,7 @@ objectClass: top
 cn: MsgUser1
 sn: MsgUser1
 uid: MsgUser1
-userPassword: msDemoPassw0rd
+userPassword: testPassw0rd
 
 dn: cn=MsgUser2,ou=users,ou=MessageSight,o=IBM
 objectClass: inetOrgPerson
@@ -62,7 +62,7 @@ objectClass: top
 cn: MsgUser2
 sn: MsgUser2
 uid: MsgUser2
-userPassword: msDemoPassw0rd
+userPassword: testPassw0rd
 
 dn: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
 objectClass: inetOrgPerson
@@ -72,7 +72,7 @@ objectClass: top
 cn: MsgUser3
 sn: MsgUser3
 uid: MsgUser3
-userPassword: msDemoPassw0rd
+userPassword: testPassw0rd
 
 dn: cn=MsgUser4,ou=users,ou=MessageSight,o=IBM
 objectClass: inetOrgPerson
@@ -82,7 +82,7 @@ objectClass: top
 cn: MsgUser4
 sn: MsgUser4
 uid: MsgUser4
-userPassword: msDemoPassw0rd
+userPassword: testPassw0rd
 
 dn: cn=MsgUser5,ou=users,ou=MessageSight,o=IBM
 objectClass: inetOrgPerson
@@ -92,7 +92,7 @@ objectClass: top
 cn: MsgUser5
 sn: MsgUser5
 uid: MsgUser5
-userPassword: msDemoPassw0rd
+userPassword: testPassw0rd
 
 dn: cn=MsgGroup1,ou=groups,ou=MessageSight,o=IBM
 objectClass: groupOfNames
@@ -100,14 +100,23 @@ objectClass: top
 cn: MsgGroup1
 member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser2,ou=users,ou=MessageSight,o=IBM
-member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
 
 dn: cn=MsgGroup2,ou=groups,ou=MessageSight,o=IBM
 objectClass: groupOfNames
 objectClass: top
 cn: MsgGroup2
 member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser4,ou=users,ou=MessageSight,o=IBM
 member: cn=MsgUser5,ou=users,ou=MessageSight,o=IBM
 
+dn: cn=AllAuthenticatedUsers,ou=groups,ou=MessageSight,o=IBM
+objectClass: groupOfNames
+objectClass: top
+cn: AllAuthenticatedUsers
+member: cn=MsgUser1,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser2,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser3,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser4,ou=users,ou=MessageSight,o=IBM
+member: cn=MsgUser5,ou=users,ou=MessageSight,o=IBM
 


### PR DESCRIPTION
This also updates the group memberships; previously the docs and code disagreed but I've settled on a 3rd configuration (with groups of 2,4,5 users) useful for labs.
